### PR TITLE
Add NotificationListenerService example plugin

### DIFF
--- a/notification_listener_service/README.md
+++ b/notification_listener_service/README.md
@@ -1,0 +1,24 @@
+# Notification Listener Service Example
+
+This directory contains an example Flutter plugin that exposes Android
+`NotificationListenerService` events to Dart using an `EventChannel`.
+
+## Usage
+
+1. Add the plugin to your Flutter project (see `pubspec.yaml`).
+2. Register the service in your Android `AndroidManifest.xml` as shown
+   in `android/src/main/AndroidManifest.xml`.
+3. Listen to notification events in Dart:
+
+```dart
+import 'package:notification_listener_service/notification_listener_service.dart';
+
+void main() {
+  NotificationListenerService.notifications.listen((event) {
+    print('Notification: $event');
+  });
+}
+```
+
+This plugin uses a platform channel to send notification data from the Android
+service to the Flutter side whenever a notification is posted.

--- a/notification_listener_service/android/src/main/AndroidManifest.xml
+++ b/notification_listener_service/android/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.notification_listener_service">
+
+    <application>
+        <service
+            android:name=".MyNotificationListenerService"
+            android:label="Notification Listener"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+    </application>
+
+</manifest>

--- a/notification_listener_service/android/src/main/kotlin/com/example/notification_listener_service/MyNotificationListenerService.kt
+++ b/notification_listener_service/android/src/main/kotlin/com/example/notification_listener_service/MyNotificationListenerService.kt
@@ -1,0 +1,23 @@
+package com.example.notification_listener_service
+
+import android.os.Bundle
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+
+class MyNotificationListenerService : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        val extras: Bundle = sbn.notification.extras
+        val title = extras.getString("android.title") ?: ""
+        val text = extras.getString("android.text") ?: ""
+        val data = mapOf(
+            "packageName" to sbn.packageName,
+            "title" to title,
+            "text" to text
+        )
+        NotificationListenerPlugin.eventSink?.success(data)
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification) {
+        // Optionally handle notification removal
+    }
+}

--- a/notification_listener_service/android/src/main/kotlin/com/example/notification_listener_service/NotificationListenerPlugin.kt
+++ b/notification_listener_service/android/src/main/kotlin/com/example/notification_listener_service/NotificationListenerPlugin.kt
@@ -1,0 +1,30 @@
+package com.example.notification_listener_service
+
+import android.content.Context
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.EventChannel
+
+class NotificationListenerPlugin : FlutterPlugin, EventChannel.StreamHandler {
+    companion object {
+        var eventSink: EventChannel.EventSink? = null
+        lateinit var context: Context
+    }
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        val eventChannel = EventChannel(binding.binaryMessenger, "notification_listener_service/events")
+        eventChannel.setStreamHandler(this)
+        context = binding.applicationContext
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        eventSink = null
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+}

--- a/notification_listener_service/lib/notification_listener_service.dart
+++ b/notification_listener_service/lib/notification_listener_service.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+
+class NotificationListenerService {
+  static const EventChannel _eventChannel =
+      EventChannel('notification_listener_service/events');
+
+  static Stream<Map<dynamic, dynamic>> get notifications =>
+      _eventChannel.receiveBroadcastStream().map(
+        (dynamic event) => Map<dynamic, dynamic>.from(event),
+      );
+}

--- a/notification_listener_service/pubspec.yaml
+++ b/notification_listener_service/pubspec.yaml
@@ -1,0 +1,9 @@
+name: notification_listener_service
+version: 0.0.1
+description: Example NotificationListenerService plugin using platform channels
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.example.notification_listener_service
+        pluginClass: NotificationListenerPlugin


### PR DESCRIPTION
## Summary
- add Flutter NotificationListenerService plugin example
- show how to capture notifications on Android and forward via platform channels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844f7e167d88320b4d3458174229833